### PR TITLE
Cleared up printed output, cleared up comments and readme, and small bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 
+*.sublime-project
+
 *.m3u
 
 *.txt

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This python3 script is for exporting tracklists directly from an Ableton session
 - Also some attempts are made to remove anything from the clip names that is not Artist - Title.
 
 If all goes well, your output should read something like:
-`
-Found 27 tracks in coolmix.als.
-Created tracklist at /fullpath/coolmix tracklist.txt
-`
+
+`Found 27 tracks in coolmix.als.`
+`Created tracklist at /fullpath/coolmix tracklist.txt`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 This python3 script is for exporting tracklists directly from an Ableton session file. Raison d'etre is that I thought there must be a way to do this that doesn't involve writing it down myself!
 
-Upon executing, a file select window lets you select a .als file. The names and start times of all audioclips in the session are extracted, and converted into MM:SS format timestamps. Also a some attempts are made to remove anything from the clip names that is not Artist - Title.
+- Upon executing, a file select window lets you select a .als file. 
+- The names and start times of all audioclips in the arrangement view (not the session / clip view) are extracted. The names assigned to the clips in Ableton are used, not the names of the files on disk.
+- The start times are converted into MM:SS format timestamps.
+	- 120 bpm is assumed throughout the project! Compensation for tempo variation might be added at a later time.
+- Also some attempts are made to remove anything from the clip names that is not Artist - Title.
+
+If all goes well, your output should read something like:
+`
+Found 27 tracks in coolmix.als.
+Created tracklist at /fullpath/coolmix tracklist.txt
+`

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ This python3 script is for exporting tracklists directly from an Ableton session
 If all goes well, your output should read something like:
 
 `Found 27 tracks in coolmix.als.`
+
 `Created tracklist at /fullpath/coolmix tracklist.txt`

--- a/tracklist.py
+++ b/tracklist.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright Felix Postma 2020
+# Felix Postma 2021
 
-# This script retrieves the time and name of audio clips rom an ableton session file,
+# This script retrieves the time and name of audio clips from an Ableton session file (.als),
 # and prints this out in a tracklist format that is suitable for pasting into Mixcloud.
 
 

--- a/tracklist.py
+++ b/tracklist.py
@@ -63,6 +63,8 @@ def timekey(e):
 ## sort according to time
 tracklist.sort(key=timekey)
 
+## isolate .als file name from full path
+alsname = re.search('[^/]+\.als$', tk.filename)[0]
 
 ## create MM:SS timestamp, and print!
 for track in tracklist:
@@ -79,5 +81,5 @@ for track in tracklist:
 	print(timestamp, name, file=open(txtname, 'a'))
 
 
-print("Created tracklist txt playlist for "+re.search('[a-zA-Z0-9]+\.als$', tk.filename)[0])
+print("Created tracklist txt playlist for "+alsname)
 

--- a/tracklist.py
+++ b/tracklist.py
@@ -66,6 +66,10 @@ tracklist.sort(key=timekey)
 ## isolate .als file name from full path
 alsname = re.search('[^/]+\.als$', tk.filename)[0]
 
+## get number of samples found in ableton session
+n = len(tracklist)
+print("Found "+str(n)+" tracks in "+alsname+".")
+
 ## create MM:SS timestamp, and print!
 for track in tracklist:
 	time = track[0]

--- a/tracklist.py
+++ b/tracklist.py
@@ -45,12 +45,6 @@ txtname = re.sub('\.als$', ' tracklist.txt', tk.filename)
 if os.path.exists(txtname):
     os.remove(txtname)
 
-## create .m3u file in .als folder
-m3uname = re.sub('\.als$', ' playlist.m3u', tk.filename)
-if os.path.exists(m3uname):
-    os.remove(m3uname)
-print('#EXTM3U', file=open(m3uname, 'a'))
-
 ## find the clips 
 for clip in root.iter('AudioClip'):
 	## get time in beats (assuming 120 bpm!!) and convert to minutes
@@ -84,11 +78,7 @@ for track in tracklist:
 	name = track[1]
 	## print to tracklist.txt
 	print(timestamp, name, file=open(txtname, 'a'))
-	## print unedited name to playlist.m3u
-	name_unclean = track[2]
-	print('#EXTINF:0,'+name_unclean+'.mp3', file=open(m3uname, 'a'))
-	print(re.sub(' ', '%20', name_unclean)+'.mp3', file=open(m3uname, 'a'))
 
 
-print("Created tracklist txt and m3u playlist for "+re.search('[a-zA-Z0-9]+\.als$', tk.filename)[0])
+print("Created tracklist txt playlist for "+re.search('[a-zA-Z0-9]+\.als$', tk.filename)[0])
 

--- a/tracklist.py
+++ b/tracklist.py
@@ -85,5 +85,5 @@ for track in tracklist:
 	print(timestamp, name, file=open(txtname, 'a'))
 
 
-print("Created tracklist txt playlist for "+alsname)
+print("Created tracklist at "+txtname)
 

--- a/tracklist.py
+++ b/tracklist.py
@@ -50,9 +50,7 @@ for clip in root.iter('AudioClip'):
 	## get time in beats (assuming 120 bpm!!) and convert to minutes
 	time = float(clip.get('Time')) / 120.0
 	## get name
-	name_unclean = clip.find('Name').get('Value')
-	## for proper tracklist: remove anything at the end of the name that matches 'my free mp3...'
-	name = re.sub('\smy[\s-]*free[\s-]*mp3[a-z.]*\s*$', '', name_unclean)
+	name = clip.find('Name').get('Value')
 	## remove album titles and such, anything thats not artist or title
 	name = re.sub('\s[-_]\s.*\s[-_]\s', ' - ', name)	
 	tracklist.append([time, name, name_unclean])

--- a/tracklist.py
+++ b/tracklist.py
@@ -70,20 +70,23 @@ alsname = re.search('[^/]+\.als$', tk.filename)[0]
 n = len(tracklist)
 print("Found "+str(n)+" tracks in "+alsname+".")
 
-## create MM:SS timestamp, and print!
-for track in tracklist:
-	time = track[0]
-	mins = math.floor(time)
-	secs = round((time % 1) * 60)
-	## add a leading 0 if seconds is a single digit
-	secsstr = str(secs)
-	if len(secsstr) == 1: 
-		secsstr = '0'+secsstr
-	timestamp = str(mins)+':'+secsstr
-	name = track[1]
-	## print to tracklist.txt
-	print(timestamp, name, file=open(txtname, 'a'))
+## Check whether a tracklist can actually be made (>0 tracks)
+if n == 0:
+	## session is empty
+	print("No tracklist has been created.")
+else:
+	## create MM:SS timestamp, and print!
+	for track in tracklist:
+		time = track[0]
+		mins = math.floor(time)
+		secs = round((time % 1) * 60)
+		## add a leading 0 if seconds is a single digit
+		secsstr = str(secs)
+		if len(secsstr) == 1: 
+			secsstr = '0'+secsstr
+		timestamp = str(mins)+':'+secsstr
+		name = track[1]
+		## print to tracklist.txt
+		print(timestamp, name, file=open(txtname, 'a'))
 
-
-print("Created tracklist at "+txtname)
-
+	print("Created tracklist at "+txtname)

--- a/tracklist.py
+++ b/tracklist.py
@@ -45,15 +45,16 @@ txtname = re.sub('\.als$', ' tracklist.txt', tk.filename)
 if os.path.exists(txtname):
     os.remove(txtname)
 
-## find the clips 
-for clip in root.iter('AudioClip'):
-	## get time in beats (assuming 120 bpm!!) and convert to minutes
-	time = float(clip.get('Time')) / 120.0
-	## get name
-	name = clip.find('Name').get('Value')
-	## remove album titles and such, anything thats not artist or title
-	name = re.sub('\s[-_]\s.*\s[-_]\s', ' - ', name)	
-	tracklist.append([time, name, name_unclean])
+## find all clips in arrangement view
+for sample in root.iter('Sample'):
+	for clip in sample.iter('AudioClip'):
+		## get time in beats (assuming 120 bpm!!) and convert to minutes
+		time = float(clip.get('Time')) / 120.0
+		## get name
+		name = clip.find('Name').get('Value')
+		## remove album titles and such, anything thats not artist or title
+		name = re.sub('\s[-_]\s.*\s[-_]\s', ' - ', name)	
+		tracklist.append([time, name])
 
 ## create key to sort by time
 def timekey(e):


### PR DESCRIPTION
The printed output now clearly states the amount of clips found and the full path of the tracklist .txt, which can help the user find the results and find out whether something is wrong with their .als file.
Readme has been updated to better reflect the behaviour and expected output of the script.
M3u is no longer generated because it's unnecessary.